### PR TITLE
`timetable.service_times`

### DIFF
--- a/data/rpcs/timetable.service_times.yaml
+++ b/data/rpcs/timetable.service_times.yaml
@@ -16,7 +16,7 @@ description: |-
 
   A visit interval is a two-element tuple containing a **time range** (the times between which the interval applies) and a **duration** (the time between arrivals during that time range, represented in minutes). Each date is represented by another two-element tuple containing the date that the entry applies to and a list of visit intervals.
 
-  Dates with only one visit interval still contain an array of visit intervals, the list is just one element long. Dates with no service (0 visit intervals), will contain an empty array.
+  Dates with only one visit interval still contain an array of visit intervals, the list is just one element long. Dates with no service (0 visit intervals), will contain an empty array. There is no set maximum to the number of intervals returned for each date.
 
   Intervals that wrap the midnight boundary represent the end of their time range as a duration since the most recent midnight. In most cases, the end of the interval will occur before the start of the first visit interval on the following day.
 

--- a/data/rpcs/timetable.service_times.yaml
+++ b/data/rpcs/timetable.service_times.yaml
@@ -1,8 +1,8 @@
-name: Timetable.service_times
+name: timetable.service_times
 id: timetable_service_times
 spec:
-  call: 'timetable.service_times(station : String, route : String)'
-  return: '[(date-of-service, [((start-time, end-time), visit-interval), ...]), ...]'
+  call: 'timetable.service_times(station, route)'
+  return: '[(date, [((start, end), interval), ...]), ...]'
 meta:
   since: v0.1
   accessibility: public
@@ -12,103 +12,55 @@ links:
 
 
 description: |-
-  If the result list contains no entries, an empty array will be returned.
+  Returns a 7-element array containing visit intervals for each day in the week following the date on which the call is made. The first entry represents the date the call is made, and the last entry represents the date one week after the previous day. For example, a request made on a Saturday will contain intervals for Saturday through the following Friday.
+
+  A visit interval is a two-element tuple containing a **time range** (the times between which the interval applies) and a **duration** (the time between arrivals during that time range, represented in minutes). Each date is represented by another two-element tuple containing the date that the entry applies to and a list of visit intervals.
+
+  Dates with only one visit interval still contain an array of visit intervals, the list is just one element long. Dates with no service (0 visit intervals), will contain an empty array.
+
+  Intervals that wrap the midnight boundary represent the end of their time range as a duration since the most recent midnight. In most cases, the end of the interval will occur before the start of the first visit interval on the following day.
 
 
-parameters: []
+parameters:
+  - name: station
+    type: String
+    required: true
+    description: The identifier of the station in question.
+  - name: route
+    type: String
+    required: true
+    description: The route for which visit intervals are calculated.
 
 
-samples:
-  Default:
-    call: |-
-      timetable.service_times('BUS123', '1B')
-    return: |-
-      [
-        (20170325, [
-            ((06:45:00, 07:50:00), 00:00:10),
-            ((08:00:00, 16:55:00), 00:00:05),
-            ((17:00:00, 22:50:00), 00:00:20)
-          ]
-        ),
-        (20170326, [
-            ((00:00:00, 03:00:00), 00:00:20),
-            ((09:00:00, 22:00:00), 00:00:10),
-            ((22:00:00, 03:00:00), 00:00:30)
-          ]
-        ),
-        (20170327, []),
-        (20170328, [
-            ((06:45:00, 07:50:00), 00:00:10),
-            ((08:00:00, 16:55:00), 00:00:05),
-            ((17:00:00, 22:50:00), 00:00:10)
-          ]
-        )
-        ...
-      ]
-
-  Commented:
-    call: |-
-      timetable.service_times('BUS123', '1B')
-    return: |-
-      # Array of service records.
-      # This array will always contain 7 entries, each one representing a day of the
-      # week. The first entry will always correspond to the current date according
-      # to the RPC provider.
-      # In this example, the first entry is a Saturday. The final entry would be the
-      # following Friday.
-      [
-        # Service record
-        (
-          # Date of service entry
-          20170325, #=> Saturday
-          # Array of visit intervals
-          [
-            # Interval record
-            (
-              # time range of visit interval
-              (06:45:00, 07:50:00),
-              # visit interval
-              00:00:10
-            ),
-            # mid-day changes to a service's visit interval are represented as
-            # separate elements in the intervals array.
-            ((08:00:00, 16:55:00), 00:00:05), #=> 8am- 4:55pm, every  5 minutes
-            ((17:00:00, 22:50:00), 00:00:10)  #=> 5pm-10:50pm, every 10 minutes
-          ]
-        ),
-
-        # Dates with only one interval record will still contain that record in an
-        # array to maintain consistency.
-        (
-          20170326, #=> Sunday
-          [
-            ((00:00:00, 03:00:00), 00:00:30),  #=> 5pm-10:50pm, every 10 minutes
-            ((09:00:00, 22:00:00), 00:00:30),
-            # Intervals that wrap the midnight boundary represent the end of their
-            # time range as a duration since the most recent midnight. This *should*
-            # never be later than the start of the time range.
-            ((22:00:00, 03:00:00), 00:00:30)  #=> 5pm-10:50pm, every 10 minutes
-          ]
-        ),
-
-        # For consistency, dates on which no service is provided will contain a blank
-        # array value.
-        (
-          20170327, #=> Monday
-          []
-        ),
-
-        # Even if multiple dates contain the same interval records, they will be
-        # listed as distinct service records. It is the client's responsibility to
-        # group these records by date if desired.
-        (
-          20170328, #=> Tuesday
-          [
-            ((06:45:00, 07:50:00), 00:00:10),
-            ((08:00:00, 16:55:00), 00:00:05),
-            ((17:00:00, 22:50:00), 00:00:10)
-          ]
-        )
-
-        ...
-      ]
+samples: |-
+  # Assuming this call is made on 20170325, the first entry is a Saturday. The
+  # final entry, then, is the following Friday.
+  timetable.service_times('BUS123', '1B')
+  #=>
+  [
+    ('20170325', [(('06:45:00', '07:50:00'), 10.0), # 6:45am-7:50am, 10 min.
+                  (('08:00:00', '16:55:00'), 5.0),  # 8:00am-4:55pm, 5 min.
+                  (('17:00:00', '22:50:00'), 20.0)] # etc...
+    ),
+    # Dates with only one interval record will still contain that record in an
+    # array to maintain consistency.
+    ('20170326', [(('00:00:00', '00:00:00'), 2.0)]),
+    # Same for dates with no intervals. The array will be blank.
+    ('20170327', []),
+    # Even if multiple dates contain the same interval records, they will be
+    # listed as distinct service records. It is the client's responsibility to
+    # group these records by date if desired.
+    ('20170328', [(('06:45:00', '07:50:00'), 1.0),
+                  (('08:00:00', '16:55:00'), 0.0),
+                  (('17:00:00', '22:50:00'), 1.0)]
+    ),
+    # The last visit interval for this date ends at 2:50am the following day. It is
+    # represented as `02:50:00` instead of `26:50:00` for better compatibility
+    # across DateTime parsing libraries.
+    ('20170329', [(('06:45:00', '07:50:00'), 1.0),
+                  (('08:00:00', '16:55:00'), 0.0),
+                  (('17:00:00', '02:50:00'), 1.0)]
+    ),
+    ('20170330', []),
+    ('20170331', [])
+  ]

--- a/data/rpcs/timetable.service_times.yaml
+++ b/data/rpcs/timetable.service_times.yaml
@@ -20,6 +20,7 @@ description: |-
 
   Intervals that wrap the midnight boundary represent the end of their time range as a duration since the most recent midnight. In most cases, the end of the interval will occur before the start of the first visit interval on the following day.
 
+  All dates and times are relative to the timezone defined by the agency.
 
 parameters:
   - name: station


### PR DESCRIPTION
Based on #1, continuing #2.

`timetable.service_times` is a convenience function to allow clients to display information about the times that a service is available. The function returns a 7-element array containing visit intervals for each of the next 7 days. The goal is to allow clients to display information such as "Route 13 stops here Mon-Fri, 7:00am-6:00pm, every 5 min" via a single call, rather than having to build up this information through repeated calls to `visits_between` or similar.

## RPC Merge Checklist
- [X] **Parameter definitions.** Each parameter to the RPC has a type and short description in the `parameters` section.
- [x] **Description.** Fully describes general use case as well as common or explicit corner cases.
- [X] **Complete Sample.** At least one sample of the call showing full invocation and a complete response (no shorthand).
- [X] **Links.** Where applicable, link back to discussion about the call.